### PR TITLE
Error handling: added HTTP server and HTTP peer handler

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/mailgun/groupcache/v2"
+	"accedo.io/groupcache/v2"
 )
 
 func ExampleUsage() {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/mailgun/groupcache/v2
+module accedo.io/groupcache/v2
 
 require (
 	github.com/golang/protobuf v1.3.1
+	github.com/pkg/errors v0.9.1
 	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.6.0
 )
 
-go 1.13
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -4,13 +4,15 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
+github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
-github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=

--- a/groupcache.go
+++ b/groupcache.go
@@ -88,7 +88,7 @@ func GetGroup(name string) *Group {
 // completes.
 //
 // The group name must be unique for each getter.
-func NewGroup(name string, cacheBytes int64, getter Getter, opts ...GroupOpts) *Group {
+func NewGroup(name string, cacheBytes int64, getter Getter, opts ...GroupOption) *Group {
 	g := newGroup(name, cacheBytes, getter, nil)
 	for _, optFn := range opts {
 		optFn(g)
@@ -130,9 +130,9 @@ func newGroup(name string, cacheBytes int64, getter Getter, peers PeerPicker) *G
 	return g
 }
 
-type GroupOpts func(group *Group)
+type GroupOption func(group *Group)
 
-func PeerErrorHandlerOption(handler PeerErrorHandler) GroupOpts {
+func WithPeerErrorHandler(handler PeerErrorHandler) GroupOption {
 	return func(group *Group) {
 		group.peerErrorHandler = handler
 	}

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	pb "github.com/mailgun/groupcache/v2/groupcachepb"
-	"github.com/mailgun/groupcache/v2/testpb"
+	pb "accedo.io/groupcache/v2/groupcachepb"
+	"accedo.io/groupcache/v2/testpb"
 )
 
 var (

--- a/peers.go
+++ b/peers.go
@@ -21,7 +21,7 @@ package groupcache
 import (
 	"context"
 
-	pb "github.com/mailgun/groupcache/v2/groupcachepb"
+	pb "accedo.io/groupcache/v2/groupcachepb"
 )
 
 // ProtoGetter is the interface that must be implemented by a peer.


### PR DESCRIPTION
Added ability to specify custom error handlers on the HTTP pool, both on client and server side. This enables:
- Conditional local retries based on details of the error that occurred during the remote load (e.g. retry locally on network error and timeouts but not on "known" errors such as not found or bad requests)
- The error may be rewritten before bubbling up to the calling `group.Get()` function
- The error can be serialized/deserialize and sent in the HTTP response body by the remote pper, to forward extra information about the error and in many cases skip a local recalculation on error
- Errors may be logged differently based on their severity, and may use any logging framework. They may also include fields related to the current context such as trace ids, or be skipped altogether for "expected" errors
- Some errors (e.g. the ones not strictly related to groupcache issues) may skip incrementing the remote load errors stats

If the error handlers aren't set, this version behaves the same as the original mailgun groupcache, except some wrapped error types. The default implementation for both error handlers is mostly a copy and paste of the preexisting source code.