### PR TITLE
Error handling: added Unwrap to RemoteLoadError and fixed URL encoding

### DIFF
--- a/http.go
+++ b/http.go
@@ -268,8 +268,8 @@ func (h *httpGetter) makeRequest(ctx context.Context, method string, in *pb.GetR
 	u := fmt.Sprintf(
 		"%v%v/%v",
 		h.baseURL,
-		url.QueryEscape(in.GetGroup()),
-		url.QueryEscape(in.GetKey()),
+		url.PathEscape(in.GetGroup()),
+		url.PathEscape(in.GetKey()),
 	)
 	req, err := http.NewRequest(method, u, nil)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -383,3 +383,7 @@ func newRemoteLoadErrorWithResp(get *pb.GetRequest, resp http.Response, body []b
 func (r RemoteLoadError) Error() string {
 	return fmt.Sprintf("remote load error: %v", r.Err)
 }
+
+func (r RemoteLoadError) Unwrap() error {
+	return r.Err
+}


### PR DESCRIPTION
- Error: RemoteLoadError now implements Unwrap to make it easier to handle the root cause of the remote load errors
- HTTP handler: switched from QueryEscape to PathEscape for the cache group and key as they are indeed in the path, and not the query params, which would cause 301s to be returned if a cache key contained a /