### PR TITLE
Peers: added ability to override the peer picker per group

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -132,6 +132,16 @@ func newGroup(name string, cacheBytes int64, getter Getter, peers PeerPicker) *G
 
 type GroupOption func(group *Group)
 
+// WithPeerPicker allows the group to be created using a different set of peers than the normal set (that is globally set). This may allow using the group with
+// the local node only, for some local LRU + single-flight cache implementation identical to distributed ones. This is a 'cleaner' way of specifying the peers
+// to use for a group rather than relying on the 'portPicker' global variable that the original implementation uses.
+func WithPeerPicker(pickerFn PeerPicker) GroupOption {
+	return func(group *Group) {
+		group.peers = pickerFn
+	}
+}
+
+// WithPeerErrorHandler allows to override the way remote load errors are processed.
 func WithPeerErrorHandler(handler PeerErrorHandler) GroupOption {
 	return func(group *Group) {
 		group.peerErrorHandler = handler


### PR DESCRIPTION
- Peers: added ability to override the peer picker per group, which allows individual groups to only be used locally for instance (for single-flight + LRU with expiration caches), while retaining the same semantic - including error handling, metrics reporting, registration, code style, etc. - as distributed caches

To be used in one-core in services that request the same things very often while they never change (e.g. locales, api-service-info, etc.).