### PR TITLE
Peer selection: limited recursive remote load restrictions to matching group+key requests

### DIFF
--- a/consistenthash/consistenthash.go
+++ b/consistenthash/consistenthash.go
@@ -82,3 +82,19 @@ func (m *Map) Get(key string) string {
 
 	return m.hashMap[m.keys[idx]]
 }
+
+type KeyOwner struct {
+	Key  int
+	Peer string
+}
+
+func (m *Map) KeyOwners() []KeyOwner {
+	owners := make([]KeyOwner, len(m.keys))
+	for i, key := range m.keys {
+		owners[i] = KeyOwner{
+			Key:  key,
+			Peer: m.hashMap[key],
+		}
+	}
+	return owners
+}

--- a/groupcache.go
+++ b/groupcache.go
@@ -366,10 +366,10 @@ func (g *Group) load(ctx context.Context, key string, dest Sink) (value ByteView
 
 		if peer, ok := g.peers.PickPeer(key); ok {
 
-			// A remote load is needed. Check first if the request is already itself coming from a remote node, and only allow the request to be recursively sent
-			// to another remote node if recursive remote loads are permitted, and if the destination peer is not the same as the source peer. Otherwise: return
-			// an error that the source node will interpret as requiring local computation of the key.
-			if m := IncomingRemoteLoadMetadataFromContext(ctx); m.IsRemoteLoad && (!m.RecursiveRemoteLoadAllowed || strings.HasPrefix(peer.GetURL(), m.SourcePeer)) {
+			// A remote load is needed. Check first if the request is already itself coming from a remote node for the same group and key, and only allow the
+			// request to be recursively sent to another remote node if recursive remote loads are permitted, and if the destination peer is not the same as the
+			// source peer. Otherwise: return an error that the source node will interpret as requiring local computation of the key.
+			if m := IncomingRemoteLoadMetadataFromContext(ctx); (m.IsRemoteLoad && m.Group == g.name && m.Key == key) && (!m.RecursiveRemoteLoadAllowed || strings.HasPrefix(peer.GetURL(), m.SourcePeer)) {
 				return nil, newRecursiveRemoteLoadForbiddenError(g.name, key, m.SourcePeer, peer.GetURL(), m.RecursiveRemoteLoadAllowed)
 			}
 

--- a/http.go
+++ b/http.go
@@ -41,8 +41,11 @@ const (
 type remoteLoadMetadataContextKey struct{}
 
 type IncomingRemoteLoadMetadata struct {
-	IsRemoteLoad               bool
-	SourcePeer                 string
+	IsRemoteLoad bool
+	Group        string
+	Key          string
+	SourcePeer   string
+
 	RecursiveRemoteLoadAllowed bool
 }
 
@@ -203,6 +206,12 @@ func (p *HTTPPool) GetAll() []ProtoGetter {
 	return res
 }
 
+func (p *HTTPPool) KeyOwners() []consistenthash.KeyOwner {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.peers.KeyOwners()
+}
+
 func (p *HTTPPool) PickPeer(key string) (ProtoGetter, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -224,8 +233,6 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = r.Context()
 	}
 
-	ctx = p.setIncomingRemoteLoadMetadataOnContext(ctx, r.Header)
-
 	// Parse request.
 	if !strings.HasPrefix(r.URL.Path, p.opts.BasePath) {
 		panic("HTTPPool serving unexpected path: " + r.URL.Path)
@@ -237,6 +244,8 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	groupName := parts[0]
 	key := parts[1]
+
+	ctx = p.setIncomingRemoteLoadMetadataOnContext(ctx, r.Header, groupName, key)
 
 	// Fetch the value for this group/key.
 	group := GetGroup(groupName)
@@ -283,9 +292,12 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
-func (p *HTTPPool) setIncomingRemoteLoadMetadataOnContext(ctx context.Context, rh http.Header) context.Context {
+func (p *HTTPPool) setIncomingRemoteLoadMetadataOnContext(ctx context.Context, rh http.Header, group, key string) context.Context {
 	m := &IncomingRemoteLoadMetadata{
 		IsRemoteLoad: true,
+
+		Group: group,
+		Key:   key,
 
 		RecursiveRemoteLoadAllowed: p.opts.AllowRecursiveRemoteLoad,
 		SourcePeer:                 rh.Get(RemoteLoadSourcePeerHeader),
@@ -468,8 +480,8 @@ func newRecursiveRemoteLoadForbiddenError(group, key, sourcePeer, destinationPee
 }
 
 func (r RecursiveRemoteLoadForbiddenError) Error() string {
-	return fmt.Sprintf("the current node does not own the requested cache key (%q), "+
+	return fmt.Sprintf("the current node does not own the requested cache key (group:%s, key:%s), "+
 		"and the current request is already being handled as part of a remote load. This node either does not allow recursive remote loads (recursiveRemoteLoadAllowed: %t), "+
-		"or the destination node (%q) has been identified as being the same as the source node (%q). Please compute the response on the source node",
-		r.key, r.recursiveRemoteLoadAllowed, r.determinedDestinationPeer, r.sourcePeer)
+		"or the destination node (%q) has been identified as being the same as the source node (%q) for the same cache group and key. Please compute the response on the source node",
+		r.group, r.key, r.recursiveRemoteLoadAllowed, r.determinedDestinationPeer, r.sourcePeer)
 }


### PR DESCRIPTION
- Key owners: added getter to retrieve the list of peers for each registered key boundary in the key ring
- Peer selection: remote loads that themselves cause other remote loads in order groups or for a different keys should not be considered "recursive" remote loads

The check I added was a bit too harsh as it considered any remote load to the seemingly same peer occurring within a remote load as suspicious, even though that may be a valid use-case when the requested group or key differs. Quite hard to debug, and we have very few cases of that, the main one being in content-catalog when getting the CatalogRefreshInfo.

To help a little, I also added a way to get the key mapping with the key boundary -> peer URL, and expose that in a management endpoint. This will be added to cacher.